### PR TITLE
Support audience claim as string or array

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -58,9 +58,11 @@ func (c StandardClaims) Valid() error {
 	return vErr
 }
 
-// Extracts an array of audience values from the aud field.
+// ExtractAudience extracts an array of audience values from the aud field.
 func ExtractAudience(c *StandardClaims) []string {
 	switch c.Audience.(type) {
+	case nil:
+		return []string{}
 	case []interface{}:
 		auds := make([]string, len(c.Audience.([]interface{})))
 		for i, value := range c.Audience.([]interface{}) {
@@ -74,7 +76,7 @@ func ExtractAudience(c *StandardClaims) []string {
 	}
 }
 
-// Compares the aud claim against cmp.
+// VerifyAudience compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
 	audiences := ExtractAudience(c)

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,0 +1,105 @@
+package jwt
+
+import (
+	"testing"
+)
+
+// Test StandardClaims instances with an audience value populated in a string, []string and []interface{}
+var audienceValue = "Aud"
+var unmatchedAudienceValue = audienceValue + "Test"
+var claimWithAudience = []StandardClaims{
+	{
+		audienceValue,
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]string{audienceValue, unmatchedAudienceValue},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]interface{}{audienceValue, unmatchedAudienceValue},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+}
+
+// Test StandardClaims instances with no aduences within empty []string and []interface{} collections.
+var claimWithoutAudience = []StandardClaims{
+	{
+		[]string{},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]interface{}{},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+}
+
+func TestExtractAudienceWithAudienceValues(t *testing.T) {
+	for _, data := range claimWithAudience {
+		var aud = ExtractAudience(&data)
+		if len(aud) == 0 || aud[0] != audienceValue {
+			t.Errorf("The audience value was not extracted properly")
+		}
+	}
+}
+
+func TestExtractAudience_WithoutAudienceValues(t *testing.T) {
+	for _, data := range claimWithoutAudience {
+		var aud = ExtractAudience(&data)
+		if len(aud) != 0 {
+			t.Errorf("An audience value should not have been extracted")
+		}
+	}
+}
+
+var audWithValues = [][]string{
+	[]string{audienceValue},
+	[]string{"Aud1", "Aud2", audienceValue},
+}
+
+var audWithLackingOriginalValue = [][]string{
+	[]string{},
+	[]string{audienceValue + "1"},
+	[]string{"Aud1", "Aud2", audienceValue + "1"},
+}
+
+func TestVerifyAud_ShouldVerifyExists(t *testing.T) {
+	for _, data := range audWithValues {
+		if !verifyAud(data, audienceValue, true) {
+			t.Errorf("The audience value was not verified properly")
+		}
+	}
+}
+
+func TestVerifyAud_ShouldVerifyDoesNotExist(t *testing.T) {
+	for _, data := range audWithValues {
+		if !verifyAud(data, audienceValue, true) {
+			t.Errorf("The audience value was not verified properly")
+		}
+	}
+}

--- a/claims_test.go
+++ b/claims_test.go
@@ -37,8 +37,17 @@ var claimWithAudience = []StandardClaims{
 	},
 }
 
-// Test StandardClaims instances with no aduences within empty []string and []interface{} collections.
+// Test StandardClaims instances with no audiences within empty []string and []interface{} collections.
 var claimWithoutAudience = []StandardClaims{
+	{
+		nil,
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
 	{
 		[]string{},
 		123123,

--- a/map_claims.go
+++ b/map_claims.go
@@ -13,8 +13,18 @@ type MapClaims map[string]interface{}
 // Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
-	aud, _ := m["aud"].(string)
-	return verifyAud(aud, cmp, req)
+	switch aud := m["aud"].(type) {
+	case []string:
+		return verifyAud(aud, cmp, req)
+	case []interface{}:
+		auds := make([]string, len(aud))
+		for i, value := range aud {
+			auds[i] = value.(string)
+		}
+		return verifyAud(auds, cmp, req)
+	default:
+		return verifyAud([]string{aud.(string)}, cmp, req)
+	}
 }
 
 // Compares the exp claim against cmp.

--- a/map_claims_tests.go
+++ b/map_claims_tests.go
@@ -1,0 +1,46 @@
+package jwt
+
+import (
+	"testing"
+)
+
+var audFixedValue = "Aud"
+var audClaimsMapsWithValues = []MapClaims{
+	{
+		"aud": audFixedValue,
+	},
+	{
+		"aud": []string{audFixedValue},
+	},
+	{
+		"aud": []interface{}{audFixedValue},
+	},
+}
+
+var audClaimsMapsWithoutValues = []MapClaims{
+	{},
+	{
+		"aud": []string{},
+	},
+	{
+		"aud": []interface{}{},
+	},
+}
+
+// Verifies that for every form of the "aud" field, the audFixedValue is always verifiable
+func TestVerifyAudienceWithVerifiableValues(t *testing.T) {
+	for _, data := range audClaimsMapsWithValues {
+		if !data.VerifyAudience(audFixedValue, true) {
+			t.Errorf("The audience value was not extracted properly")
+		}
+	}
+}
+
+// Verifies that for every empty form of the "aud" field, the audFixedValue cannot be verified
+func TestVerifyAudienceWithoutVerifiableValues(t *testing.T) {
+	for _, data := range audClaimsMapsWithoutValues {
+		if data.VerifyAudience(audFixedValue, true) {
+			t.Errorf("The audience should not verify")
+		}
+	}
+}


### PR DESCRIPTION
This was created based on the following PR:
dgrijalva#286

```
As per the JWT spec, the aud claim field can be either a single string value 
or an array of strings.

jwt-go would completely drop array values as the StandardClaims struct's 
Audience field is a string value and the value is dropped upon deserialization.
```